### PR TITLE
feat: set packageRules to support github-tags

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,4 +1,46 @@
 {
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "golang/go",
+        "golang/tools",
+        "kubernetes/kubectl"
+      ],
+      "matchPaths": [
+        ".aqua.yaml",
+        ".aqua.yml",
+        "aqua.yaml",
+        "aqua.yml"
+      ],
+      "matchDatasources": ["github-releases"],
+      "enabled": false
+    },
+    {
+      "matchPaths": [
+        ".aqua.yaml",
+        ".aqua.yml",
+        "aqua.yaml",
+        "aqua.yml"
+      ],
+      "matchDatasources": ["github-tags"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "golang/go",
+        "golang/tools",
+        "kubernetes/kubectl"
+      ],
+      "matchPaths": [
+        ".aqua.yaml",
+        ".aqua.yml",
+        "aqua.yaml",
+        "aqua.yml"
+      ],
+      "matchDatasources": ["github-tags"],
+      "enabled": true
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["\\.?aqua\\.ya?ml"],
@@ -7,6 +49,14 @@
         " +['\"]?name['\"]? *: +['\"]?(?<depName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*@(?<currentValue>[^'\" \\n]+)['\"]?"
       ],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["\\.?aqua\\.ya?ml"],
+      "matchStrings": [
+        " +['\"]?(version|ref)['\"]? *: +['\"]?(?<currentValue>[^'\" \\n]+?)['\"]? +# renovate: depName=(?<depName>[^\\n]+)",
+        " +['\"]?name['\"]? *: +['\"]?(?<depName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*@(?<currentValue>[^'\" \\n]+)['\"]?"
+      ],
+      "datasourceTemplate": "github-tags"
     },
     {
       "fileMatch": ["^\\.github/.*\\.ya?ml$"],

--- a/file.json
+++ b/file.json
@@ -1,4 +1,37 @@
 {
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "golang/go",
+        "golang/tools",
+        "kubernetes/kubectl"
+      ],
+      "matchPaths": [
+        "{{arg0}}"
+      ],
+      "matchDatasources": ["github-releases"],
+      "enabled": false
+    },
+    {
+      "matchPaths": [
+        "{{arg0}}"
+      ],
+      "matchDatasources": ["github-tags"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "golang/go",
+        "golang/tools",
+        "kubernetes/kubectl"
+      ],
+      "matchPaths": [
+        "{{arg0}}"
+      ],
+      "matchDatasources": ["github-tags"],
+      "enabled": true
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["{{arg0}}"],
@@ -7,6 +40,14 @@
         " +['\"]?name['\"]? *: +['\"]?(?<depName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*@(?<currentValue>[^'\" \\n]+)['\"]?"
       ],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["{{arg0}}"],
+      "matchStrings": [
+        " +['\"]?(version|ref)['\"]? *: +['\"]?(?<currentValue>[^'\" \\n]+?)['\"]? +# renovate: depName=(?<depName>[^\\n]+)",
+        " +['\"]?name['\"]? *: +['\"]?(?<depName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*@(?<currentValue>[^'\" \\n]+)['\"]?"
+      ],
+      "datasourceTemplate": "github-tags"
     },
     {
       "fileMatch": ["{{arg0}}"],


### PR DESCRIPTION
#191

## What

* Update some packages with `github-tags` datasource
* Disable `github-releases` datasource for packages using `github-tags` datasource to suppress `Dependency Lookup Warnings`

## How

1. Add RegexManager's Rule to update packages with `github-tags` datasource
1. Disable `github-tags` datasource in aqua.yaml by default
1. Disable `github-releases` datasource in aqua.yaml for some packages
1. Enable `github-tags` datasource in aqua.yaml for some packages

## Test

https://github.com/suzuki-shunsuke/test-renovate/blob/efa495ea1edcda1b55d8053f0b89eccf12388f75/aqua.yaml

The following prs were created.

* https://github.com/suzuki-shunsuke/test-renovate/pull/160
* https://github.com/suzuki-shunsuke/test-renovate/pull/161
* https://github.com/suzuki-shunsuke/test-renovate/pull/162
* https://github.com/suzuki-shunsuke/test-renovate/pull/163

No warning.

https://github.com/suzuki-shunsuke/test-renovate/issues/106

<img width="929" alt="image" src="https://user-images.githubusercontent.com/13323303/184264938-cdff6105-1233-4b92-a1ff-e224e0727f6f.png">

## Reference

* https://docs.renovatebot.com/configuration-options/#regexmanagers
* https://docs.renovatebot.com/configuration-options/#packagerules