### PR TITLE
fix: fix the packageName of kubectl-convert

### DIFF
--- a/default.json
+++ b/default.json
@@ -269,6 +269,18 @@
          "packageNameTemplate": "ipinfo/cli"
       },
       {
+         "datasourceTemplate": "github-releases",
+         "depNameTemplate": "kubernetes/kubectl-convert",
+         "fileMatch": [
+            "\\.?aqua\\.ya?ml"
+         ],
+         "matchStrings": [
+            " +(?:version|'version'|\"version\") *: +['\"]?(?<currentValue>[^'\" \\n]+)['\"]? +# renovate: depName=(?<depName>(?<packageName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:name|'name'|\"name\") *: +['\"]?(?<depName>(?<packageName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)['\"]?"
+         ],
+         "packageNameTemplate": "kubernetes/kubernetes"
+      },
+      {
          "datasourceTemplate": "github-tags",
          "depNameTemplate": "kubernetes/kubectl",
          "extractVersionTemplate": "^kubernetes-(?<version>.*)$",

--- a/file.json
+++ b/file.json
@@ -183,6 +183,18 @@
          "packageNameTemplate": "ipinfo/cli"
       },
       {
+         "datasourceTemplate": "github-releases",
+         "depNameTemplate": "kubernetes/kubectl-convert",
+         "fileMatch": [
+            "{{arg0}}"
+         ],
+         "matchStrings": [
+            " +(?:version|'version'|\"version\") *: +['\"]?(?<currentValue>[^'\" \\n]+)['\"]? +# renovate: depName=(?<depName>(?<packageName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:name|'name'|\"name\") *: +['\"]?(?<depName>(?<packageName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)['\"]?"
+         ],
+         "packageNameTemplate": "kubernetes/kubernetes"
+      },
+      {
          "datasourceTemplate": "github-tags",
          "depNameTemplate": "kubernetes/kubectl",
          "extractVersionTemplate": "^kubernetes-(?<version>.*)$",

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -61,6 +61,10 @@
     datasourceTemplate: "go",
   },
 
+  kubectlConvert: $.packageRegexManager + {
+    depNameTemplate: "kubernetes/kubectl-convert",
+    packageNameTemplate: "kubernetes/kubernetes",
+  },
   kubectl: $.prefixRegexManager("kubernetes/kubectl", "v") + {
     extractVersionTemplate: "^kubernetes-(?<version>.*)$",
     datasourceTemplate: "github-tags",
@@ -101,6 +105,7 @@
     $.ipinfo("randip"),
     $.ipinfo("grepip"),
     $.ipinfo("range2ip"),
+    $.kubectlConvert,
     $.kubectl,
     $.kustomize,
     $.prefixRegexManager("mongodb/mongodb-atlas-cli/atlascli", "atlascli/") + {


### PR DESCRIPTION
Fix the warning.

> ⚠ Dependency Lookup Warnings ⚠
> Renovate failed to look up the following dependencies: kubernetes/kubectl-convert.