### PR TITLE
Fix CircleCI renovate config

### DIFF
--- a/default.json
+++ b/default.json
@@ -54,13 +54,22 @@
          "datasourceTemplate": "github-releases",
          "depNameTemplate": "aquaproj/aqua",
          "fileMatch": [
-            "^\\.github/.*\\.ya?ml$",
-            "^\\.circleci/config\\.yml$"
+            "^\\.github/.*\\.ya?ml$"
          ],
          "matchStrings": [
             " +(?:aqua_version|'aqua_version'|\"aqua_version\") *: +(?<currentValue>[^'\" \\n]+)",
             " +(?:aqua_version|'aqua_version'|\"aqua_version\") *: +'(?<currentValue>[^'\" \\n]+)'",
             " +(?:aqua_version|'aqua_version'|\"aqua_version\") *: +\"(?<currentValue>[^'\" \\n]+)\""
+         ]
+      },
+      {
+         "datasourceTemplate": "github-releases",
+         "depNameTemplate": "aquaproj/aqua",
+         "fileMatch": [
+            "^\\.circleci/config\\.ya?ml$"
+         ],
+         "matchStrings": [
+            "- aqua/aqua:\\s+version:\\s+(?<currentValue>[^'\" \\n]+)"
          ]
       },
       {

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -28,8 +28,7 @@ local utils = import 'utils.libsonnet';
     {
       // Update aqua-installer action
       fileMatch: [
-        '^\\.github/.*\\.ya?ml$',
-        '^\\.circleci/config\\.yml$',
+        '^\\.github/.*\\.ya?ml$'
       ],
       matchStrings: [
         ' +%s *: +%s' % [utils.wrapQuote('aqua_version'), utils.currentValue],
@@ -38,6 +37,15 @@ local utils = import 'utils.libsonnet';
       ],
       depNameTemplate: 'aquaproj/aqua',
       datasourceTemplate: 'github-releases',
+    },
+    {
+      // Update aqua orb
+      fileMatch: ['^\\.circleci/config\\.ya?ml$'],
+      matchStrings: [
+        '- aqua/aqua:\\s+version:\\s+%s' % [utils.currentValue],
+      ],
+      depNameTemplate: "aquaproj/aqua",
+      datasourceTemplate: "github-releases",
     },
     {
       // Update aqua-renovate-config


### PR DESCRIPTION
 Hey, thanks for adding the CircleCI support in v1.7.0.

I think the format for aqua orb is like this:
```yaml
- aqua/aqua:
    version: v2.9.1
```
In v1.7.0, it seems to me that you're deciding based on a string called 'aqua_version'. But, I'm not sure if it matches the format above.
 
It might just be a misunderstanding on my part, but I've created a PR for the correction.
