### PR TITLE
feat: support updating aqua-renovate-config in config preset (#448)

### DIFF
--- a/aqua-renovate-config.json
+++ b/aqua-renovate-config.json
@@ -1,0 +1,16 @@
+{
+   "regexManagers": [
+      {
+         "datasourceTemplate": "github-releases",
+         "depNameTemplate": "aquaproj/aqua-renovate-config",
+         "fileMatch": [
+            "{{arg0}}"
+         ],
+         "matchStrings": [
+            "\"github>aquaproj/aqua-renovate-config#(?<currentValue>[^\" \\n\\(]+)",
+            "\"github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^\" \\n\\(]+)",
+            "\"github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^\" \\n\\(]+)"
+         ]
+      }
+   ]
+}

--- a/jsonnet/aqua-renovate-config.jsonnet
+++ b/jsonnet/aqua-renovate-config.jsonnet
@@ -1,0 +1,11 @@
+local utils = import 'utils.libsonnet';
+
+{
+  regexManagers: [
+    utils.aquaRenovateConfigPreset + {
+      fileMatch: [
+        '{{arg0}}',
+      ],
+    },
+  ],
+}

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -37,6 +37,17 @@
     ' +%s *: +"%s@%s%s"' % [$.wrapQuote('name'), depName, prefix, $.currentValue],
   ],
 
+  aquaRenovateConfigPreset: {
+    // Update aqua-renovate-config
+    matchStrings: [
+      '"github>aquaproj/aqua-renovate-config#(?<currentValue>[^" \\n\\(]+)',
+      '"github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^" \\n\\(]+)',
+      '"github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^" \\n\\(]+)',
+    ],
+    datasourceTemplate: 'github-releases',
+    depNameTemplate: 'aquaproj/aqua-renovate-config',
+  },
+
   // GitHub User and Organization name doesn't include periods.
   depName: "(?<depName>(?<packageName>[^'\" .@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
   goModuleDepName: '(?<depName>golang\\.org/[^\\n]+)',


### PR DESCRIPTION
closes #448 

<details><summary>outdated comment</summary>

[The document](https://docs.renovatebot.com/config-presets/) says

>Shareable config presets must use the JSON or **JSON5** formats

but `.json5` extension is [not allowed](https://github.com/renovatebot/renovate/blob/b69416ce1745f67c9fc1d149738e2f52feb4f732/lib/config/presets/gitlab/index.spec.ts#L38). So I added only `default.json`.

(It's a bit of strange, `default.json` which has JSON5 content is allowed with WARN log)

```
 WARN: File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax. (repository=xxx/xxx)
```

</details>