### PR TITLE
fix: replace matchPackageNames with matchDepNames

### DIFF
--- a/default.json
+++ b/default.json
@@ -519,7 +519,7 @@
          "matchDatasources": [
             "github-releases"
          ],
-         "matchPackageNames": [
+         "matchDepNames": [
             "golang/go",
             "golang/tools",
             "kubernetes/kubectl",
@@ -553,7 +553,7 @@
          "matchDatasources": [
             "github-tags"
          ],
-         "matchPackageNames": [
+         "matchDepNames": [
             "golang/go",
             "golang/tools",
             "kubernetes/kubectl",

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -5,7 +5,7 @@ local utils = import 'utils.libsonnet';
     // Some packages are updated by github-tags datasource.
     // So disable github-releases against those packages.
     {
-      matchPackageNames: utils.githubTagsPackages,
+      matchDepNames: utils.githubTagsPackages,
       matchPaths: utils.aquaYAMLMatchPaths,
       matchDatasources: ['github-releases'],
       enabled: false,
@@ -18,7 +18,7 @@ local utils = import 'utils.libsonnet';
     },
     // github-tags is enabled against only those packages.
     {
-      matchPackageNames: utils.githubTagsPackages,
+      matchDepNames: utils.githubTagsPackages,
       matchPaths: utils.aquaYAMLMatchPaths,
       matchDatasources: ['github-tags'],
       enabled: true,


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#matchpackagenames

> matchPackageNames will try matching packageName first and then fall back to matching depName.
> If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release.
> Use matchDepNames instead.