### PR TITLE
fix(external-secrets/external-secrets/esoctl): ignore versions without the suffix `-esoctl`

### DIFF
--- a/default.json
+++ b/default.json
@@ -641,6 +641,12 @@
             "**/aqua.yaml",
             "**/aqua.yml"
          ]
+      },
+      {
+         "allowedVersions": "/-esoctl$/",
+         "matchDepNames": [
+            "external-secrets/external-secrets/esoctl"
+         ]
       }
    ]
 }

--- a/default.json
+++ b/default.json
@@ -566,23 +566,6 @@
             " +(?:name|'name'|\"name\") *: +'bitwarden/clients@cli-(?<currentValue>[^'\" \\n]+)'",
             " +(?:name|'name'|\"name\") *: +\"bitwarden/clients@cli-(?<currentValue>[^'\" \\n]+)\""
          ]
-      },
-      {
-         "customType": "regex",
-         "datasourceTemplate": "github-releases",
-         "depNameTemplate": "external-secrets/external-secrets/esoctl",
-         "extractVersionTemplate": "^(?<version>.*)-esoctl$",
-         "fileMatch": [
-            "\\.?aqua\\.ya?ml"
-         ],
-         "matchStrings": [
-            " +(?:version|'version'|\"version\") *: +(?<currentValue>[^'\" \\n]+)-esoctl +# renovate: depName=external-secrets/external-secrets/esoctl[ \\n]",
-            " +(?:version|'version'|\"version\") *: +'(?<currentValue>[^'\" \\n]+)-esoctl' +# renovate: depName=external-secrets/external-secrets/esoctl[ \\n]",
-            " +(?:version|'version'|\"version\") *: +\"(?<currentValue>[^'\" \\n]+)-esoctl\" +# renovate: depName=external-secrets/external-secrets/esoctl[ \\n]",
-            " +(?:name|'name'|\"name\") *: +external-secrets/external-secrets/esoctl@(?<currentValue>[^'\" \\n]+)-esoctl",
-            " +(?:name|'name'|\"name\") *: +'external-secrets/external-secrets/esoctl@(?<currentValue>[^'\" \\n]+)-esoctl'",
-            " +(?:name|'name'|\"name\") *: +\"external-secrets/external-secrets/esoctl@(?<currentValue>[^'\" \\n]+)-esoctl\""
-         ]
       }
    ],
    "packageRules": [

--- a/file.json
+++ b/file.json
@@ -505,23 +505,6 @@
             " +(?:name|'name'|\"name\") *: +'bitwarden/clients@cli-(?<currentValue>[^'\" \\n]+)'",
             " +(?:name|'name'|\"name\") *: +\"bitwarden/clients@cli-(?<currentValue>[^'\" \\n]+)\""
          ]
-      },
-      {
-         "customType": "regex",
-         "datasourceTemplate": "github-releases",
-         "depNameTemplate": "external-secrets/external-secrets/esoctl",
-         "extractVersionTemplate": "^(?<version>.*)-esoctl$",
-         "fileMatch": [
-            "{{arg0}}"
-         ],
-         "matchStrings": [
-            " +(?:version|'version'|\"version\") *: +(?<currentValue>[^'\" \\n]+)-esoctl +# renovate: depName=external-secrets/external-secrets/esoctl[ \\n]",
-            " +(?:version|'version'|\"version\") *: +'(?<currentValue>[^'\" \\n]+)-esoctl' +# renovate: depName=external-secrets/external-secrets/esoctl[ \\n]",
-            " +(?:version|'version'|\"version\") *: +\"(?<currentValue>[^'\" \\n]+)-esoctl\" +# renovate: depName=external-secrets/external-secrets/esoctl[ \\n]",
-            " +(?:name|'name'|\"name\") *: +external-secrets/external-secrets/esoctl@(?<currentValue>[^'\" \\n]+)-esoctl",
-            " +(?:name|'name'|\"name\") *: +'external-secrets/external-secrets/esoctl@(?<currentValue>[^'\" \\n]+)-esoctl'",
-            " +(?:name|'name'|\"name\") *: +\"external-secrets/external-secrets/esoctl@(?<currentValue>[^'\" \\n]+)-esoctl\""
-         ]
       }
    ]
 }

--- a/file.json
+++ b/file.json
@@ -506,5 +506,13 @@
             " +(?:name|'name'|\"name\") *: +\"bitwarden/clients@cli-(?<currentValue>[^'\" \\n]+)\""
          ]
       }
+   ],
+   "packageRules": [
+      {
+         "allowedVersions": "/-esoctl$/",
+         "matchDepNames": [
+            "external-secrets/external-secrets/esoctl"
+         ]
+      }
    ]
 }

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -23,6 +23,7 @@ local utils = import 'utils.libsonnet';
       matchDatasources: ['github-tags'],
       enabled: true,
     },
+    utils.suffixPackageRule('external-secrets/external-secrets/esoctl', '-esoctl'),
   ],
   customManagers: [
     {

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -23,7 +23,12 @@ local utils = import 'utils.libsonnet';
       matchDatasources: ['github-tags'],
       enabled: true,
     },
-    utils.suffixPackageRule('external-secrets/external-secrets/esoctl', '-esoctl'),
+    {
+      allowedVersions: '/-esoctl$/',
+      matchDepNames: [
+        'external-secrets/external-secrets/esoctl',
+      ],
+    },
   ],
   customManagers: [
     {

--- a/jsonnet/file.jsonnet
+++ b/jsonnet/file.jsonnet
@@ -1,5 +1,13 @@
 local utils = import 'utils.libsonnet';
 
 {
+  packageRules: [
+    {
+      allowedVersions: '/-esoctl$/',
+      matchDepNames: [
+        'external-secrets/external-secrets/esoctl',
+      ],
+    },
+  ],
   customManagers: utils.fileMatches(utils.argFileMatch.fileMatch, utils.customManagers),
 }

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -34,6 +34,14 @@
     datasourceTemplate: 'github-releases',
     depNameTemplate: depName,
   },
+  prefixPackageRule(depName, prefix):: {
+    matchDepNames: [depName],
+    allowedVersions: '/^%s/' % prefix,
+  },
+  suffixPackageRule(depName, suffix):: {
+    matchDepNames: [depName],
+    allowedVersions: '/%s$/' % suffix,
+  },
   ipinfo(name):: $.prefixRegexManager('ipinfo/cli/' + name, name + '-') + {
     packageNameTemplate: 'ipinfo/cli',
   },

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -26,14 +26,6 @@
     datasourceTemplate: 'github-releases',
     depNameTemplate: depName,
   },
-  prefixPackageRule(depName, prefix):: {
-    matchDepNames: [depName],
-    allowedVersions: '/^%s/' % prefix,
-  },
-  suffixPackageRule(depName, suffix):: {
-    matchDepNames: [depName],
-    allowedVersions: '/%s$/' % suffix,
-  },
   ipinfo(name):: $.prefixRegexManager('ipinfo/cli/' + name, name + '-') + {
     packageNameTemplate: 'ipinfo/cli',
   },

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -26,14 +26,6 @@
     datasourceTemplate: 'github-releases',
     depNameTemplate: depName,
   },
-  suffixRegexManager(depName, suffix):: {
-    customType: 'regex',
-    fileMatch: $.aquaYAMLFileMatch,
-    matchStrings: $.aquaPackageMatchStringsWithSuffix(depName, suffix),
-    extractVersionTemplate: '^(?<version>.*)%s$' % suffix,
-    datasourceTemplate: 'github-releases',
-    depNameTemplate: depName,
-  },
   prefixPackageRule(depName, prefix):: {
     matchDepNames: [depName],
     allowedVersions: '/^%s/' % prefix,
@@ -251,6 +243,5 @@
       datasourceTemplate: 'npm',
     },
     $.prefixRegexManager('bitwarden/clients', 'cli-'),
-    $.suffixRegexManager('external-secrets/external-secrets/esoctl', '-esoctl'),
   ]),
 }


### PR DESCRIPTION
Close #803

# Test

I've confirmed the pull request without the suffix `-esoctl` was closed.

- https://github.com/suzuki-shunsuke/test-renovate/pull/363