### PR TITLE
fix(aqua-renovate-config): support single quotes

### DIFF
--- a/aqua-renovate-config.json
+++ b/aqua-renovate-config.json
@@ -8,9 +8,9 @@
             "{{arg0}}"
          ],
          "matchStrings": [
-            "\"github>aquaproj/aqua-renovate-config#(?<currentValue>[^\" \\n\\(]+)",
-            "\"github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^\" \\n\\(]+)",
-            "\"github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^\" \\n\\(]+)"
+            "['\"]github>aquaproj/aqua-renovate-config#(?<currentValue>[^'\" \\n\\(]+)",
+            "['\"]github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^'\" \\n\\(]+)",
+            "['\"]github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^'\" \\n\\(]+)"
          ]
       }
    ]

--- a/default.json
+++ b/default.json
@@ -41,9 +41,9 @@
             "^\\.renovaterc$"
          ],
          "matchStrings": [
-            "\"github>aquaproj/aqua-renovate-config#(?<currentValue>[^\" \\n\\(]+)",
-            "\"github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^\" \\n\\(]+)",
-            "\"github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^\" \\n\\(]+)"
+            "['\"]github>aquaproj/aqua-renovate-config#(?<currentValue>[^'\" \\n\\(]+)",
+            "['\"]github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^'\" \\n\\(]+)",
+            "['\"]github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^'\" \\n\\(]+)"
          ]
       },
       {

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -53,9 +53,9 @@
     // Update aqua-renovate-config
     customType: 'regex',
     matchStrings: [
-      '"github>aquaproj/aqua-renovate-config#(?<currentValue>[^" \\n\\(]+)',
-      '"github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^" \\n\\(]+)',
-      '"github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^" \\n\\(]+)',
+      '[\'"]github>aquaproj/aqua-renovate-config#(?<currentValue>[^\'" \\n\\(]+)',
+      '[\'"]github>aquaproj/aqua-renovate-config:.*#(?<currentValue>[^\'" \\n\\(]+)',
+      '[\'"]github>aquaproj/aqua-renovate-config/.*#(?<currentValue>[^\'" \\n\\(]+)',
     ],
     datasourceTemplate: 'github-releases',
     depNameTemplate: 'aquaproj/aqua-renovate-config',


### PR DESCRIPTION
Fix a bug that aqua-renovate-config isn't updated if it is quoted by single quotes.