### PR TITLE
Revert "Revert "feat: update presets in same pull requests""

### DIFF
--- a/default.json
+++ b/default.json
@@ -630,6 +630,12 @@
          "matchDepNames": [
             "external-secrets/external-secrets/esoctl"
          ]
+      },
+      {
+         "groupName": "aquaproj/aqua-renovate-config",
+         "matchPackageNames": [
+            "aquaproj/aqua-renovate-config"
+         ]
       }
    ]
 }

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -29,6 +29,10 @@ local utils = import 'utils.libsonnet';
         'external-secrets/external-secrets/esoctl',
       ],
     },
+    {
+      matchPackageNames: ['aquaproj/aqua-renovate-config'],
+      groupName: 'aquaproj/aqua-renovate-config',
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Reverts aquaproj/aqua-renovate-config#808

Once I reverted #806 , but I found we shouldn't revert #806 .
This change is helpful to prevent other presets such as suzuki-shunsuke/renovate-config from updating aqua-renovate-config separately.