### PR TITLE
fix: detect github-tags packages in the file and base presets

### DIFF
--- a/base.json
+++ b/base.json
@@ -17,6 +17,21 @@
       },
       {
          "customType": "regex",
+         "datasourceTemplate": "github-tags",
+         "managerFilePatterns": [
+            "/\\.?aqua\\.ya?ml/"
+         ],
+         "matchStrings": [
+            " +(?:version|'version'|\"version\") *: +(?<currentValue>[^'\" \\n]+) +# renovate: depName=(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:version|'version'|\"version\") *: +'(?<currentValue>[^'\" \\n]+)' +# renovate: depName=(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:version|'version'|\"version\") *: +\"(?<currentValue>[^'\" \\n]+)\" +# renovate: depName=(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:name|'name'|\"name\") *: +(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)",
+            " +(?:name|'name'|\"name\") *: +'(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)'",
+            " +(?:name|'name'|\"name\") *: +\"(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)\""
+         ]
+      },
+      {
+         "customType": "regex",
          "datasourceTemplate": "github-releases",
          "managerFilePatterns": [
             "/\\.?aqua\\.ya?ml/"

--- a/default.json
+++ b/default.json
@@ -48,7 +48,7 @@
       },
       {
          "customType": "regex",
-         "datasourceTemplate": "github-tags",
+         "datasourceTemplate": "github-releases",
          "managerFilePatterns": [
             "/\\.?aqua\\.ya?ml$/"
          ],
@@ -63,7 +63,7 @@
       },
       {
          "customType": "regex",
-         "datasourceTemplate": "github-releases",
+         "datasourceTemplate": "github-tags",
          "managerFilePatterns": [
             "/\\.?aqua\\.ya?ml$/"
          ],

--- a/file.json
+++ b/file.json
@@ -17,6 +17,21 @@
       },
       {
          "customType": "regex",
+         "datasourceTemplate": "github-tags",
+         "managerFilePatterns": [
+            "/{{arg0}}/"
+         ],
+         "matchStrings": [
+            " +(?:version|'version'|\"version\") *: +(?<currentValue>[^'\" \\n]+) +# renovate: depName=(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:version|'version'|\"version\") *: +'(?<currentValue>[^'\" \\n]+)' +# renovate: depName=(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:version|'version'|\"version\") *: +\"(?<currentValue>[^'\" \\n]+)\" +# renovate: depName=(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)",
+            " +(?:name|'name'|\"name\") *: +(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)",
+            " +(?:name|'name'|\"name\") *: +'(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)'",
+            " +(?:name|'name'|\"name\") *: +\"(?<depName>(?<packageName>[^'\" _.@/\\n]+/[^'\" @/\\n]+)(/[^'\" /@\\n]+)*)@(?<currentValue>[^'\" \\n]+)\""
+         ]
+      },
+      {
+         "customType": "regex",
          "datasourceTemplate": "github-releases",
          "managerFilePatterns": [
             "/{{arg0}}/"

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -42,9 +42,5 @@ local utils = import 'utils.libsonnet';
         '/^\\.renovaterc$/',
       ],
     },
-    utils.packageRegexManager {
-      datasourceTemplate: 'github-tags',
-      managerFilePatterns: ['/\\.?aqua\\.ya?ml$/'],
-    },
   ]) + utils.fileMatches(['/\\.?aqua\\.ya?ml$/'], utils.customManagers),
 }

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -107,8 +107,8 @@
 
   customManagers: $.setCustomTypeRegex([
     $.packageRegexManager,
-    $.packageRegexManager + {
-      datasourceTemplate: 'github-tags'
+    $.packageRegexManager {
+      datasourceTemplate: 'github-tags',
     },
     $.registryRegexManager,
     {

--- a/jsonnet/utils.libsonnet
+++ b/jsonnet/utils.libsonnet
@@ -107,6 +107,9 @@
 
   customManagers: $.setCustomTypeRegex([
     $.packageRegexManager,
+    $.packageRegexManager + {
+      datasourceTemplate: 'github-tags'
+    },
     $.registryRegexManager,
     {
       // golang.org


### PR DESCRIPTION
## Overview

The generic `github-tags` custom manager - the `github-tags` counterpart of `packageRegexManager` that matches `name: <owner>/<repo>@<version>` and `version: ... # renovate: depName=...` - was only defined in `default.jsonnet`. The `file` and `base` presets did not include it.

As a result, packages listed in `githubTagsPackages` **without a dedicated custom manager** were never extracted under the `:file` and `:base` presets: `github-releases` is disabled for them by `packageRules`, but there was no enabled `github-tags` manager to extract them. Renovate silently stopped proposing updates for these packages.

## Affected packages

`githubTagsPackages` entries that have no dedicated custom manager and rely on the generic one:

- `anthropics/claude-code`
- `aws/aws-cli`
- `catenacyber/perfsprint`
- `golang/vuln/govulncheck`
- `twistedpair/google-cloud-sdk`
- `golang/tools`

Entries with a dedicated manager (`apache/ant`, `golang/go`, `kubernetes/kubectl`, `awslabs/mountpoint-s3`, `getdbt.com/dbt-fusion`) were unaffected - which is why this stayed hidden under `default`.

## Fix

Move the generic `github-tags` custom manager from `default.jsonnet` into the shared `utils.customManagers`, so all three presets (`default`, `file`, `base`) include it. `default.json` is functionally unchanged (only manager ordering differs); `base.json` and `file.json` gain the manager.

## Verification

Regenerated the presets with `bash scripts/generate.sh`, then ran
`renovate --dry-run=lookup` with the `:file` preset against a sample
`aqua.yaml` containing both:

- entries from `githubTagsPackages` that have no dedicated custom manager
  (e.g. `anthropics/claude-code`, `aws/aws-cli`, `catenacyber/perfsprint`,
  `golang/vuln/govulncheck`)
- a regular package not in `githubTagsPackages` (e.g. `cli/cli`)

Results:

- The `githubTagsPackages` entries are now extracted and resolved via the
  `github-tags` datasource, whereas previously they produced no update
  under the `:file`/`:base` presets. Their `github-releases` entries stay
  disabled.
- The regular package keeps resolving via `github-releases` with
  `github-tags` disabled, so there are no duplicate updates and no
  regression.

`renovate-config-validator` passes on the regenerated `default.json` and
`base.json`.
